### PR TITLE
InterruptTriggers

### DIFF
--- a/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsView.swift
+++ b/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsView.swift
@@ -49,6 +49,22 @@ struct AllSettingsView: View {
           }
 
           Section("Move") {
+            VStack {
+              Toggle("interrupt by panGesture", isOn: Binding(
+                get: { viewModel.panGestureInterrupt },
+                set: { viewModel.panGestureInterrupt = $0 }
+              ))
+              Toggle("interrupt by scrollDragging", isOn: Binding(
+                get: { viewModel.scrollDraggingInterrupt },
+                set: { viewModel.scrollDraggingInterrupt = $0 }
+              ))
+
+              Toggle("interrupt by program", isOn: Binding(
+                get: { viewModel.programInterrupt },
+                set: { viewModel.programInterrupt = $0 }
+              ))
+            }
+
             Button {
               viewModel.moveTo?(AllSettingsPositions.top.position)
             } label: {

--- a/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsViewController.swift
+++ b/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsViewController.swift
@@ -38,7 +38,26 @@ final class AllSettingsViewController: ExampleViewController {
     }
 
     viewModel.moveTo = { [weak self] position in
-      self?.bottomSheet.detents.move(to: position)
+      guard let self else { return }
+
+      var interruptTriggers: DynamicBottomSheet.InterruptTrigger = []
+
+      if viewModel.panGestureInterrupt {
+        interruptTriggers.insert(.panGesture)
+      }
+
+      if viewModel.scrollDraggingInterrupt {
+        interruptTriggers.insert(.scrollDragging)
+      }
+
+      if viewModel.programInterrupt {
+        interruptTriggers.insert(.program)
+      }
+
+      self.bottomSheet.detents.move(
+        to: position,
+        interruptTriggers: interruptTriggers
+      )
     }
   }
   

--- a/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsViewModel.swift
+++ b/Example/ExampleApp/ExampleApp/AllSettings/AllSettingsViewModel.swift
@@ -52,6 +52,10 @@ final class AllSettingsViewModel: ObservableObject {
 
   @Published var cornerRadius: CGFloat = 10
 
+  @Published var panGestureInterrupt: Bool = true
+  @Published var scrollDraggingInterrupt: Bool = true
+  @Published var programInterrupt: Bool = true
+
   @Published var shadowColor: CGColor? = UIColor.black.withAlphaComponent(0.5).cgColor
 
   @Published var shadowOpacity: Float = 0.5

--- a/Sources/DynamicBottomSheet/DynamicBottomSheet+BottomBar.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet+BottomBar.swift
@@ -2,7 +2,8 @@
 //  DynamicBottomSheet+BottomBar.swift
 //  DynamicBottomSheet
 //
-//  Created by Savva Shuliatev on 27.11.2024.
+//  Copyright (c) 2024 Savva Shuliatev
+//  This code is covered by the MIT License.
 //
 
 import UIKit

--- a/Sources/DynamicBottomSheet/DynamicBottomSheet+InterruptTrigger.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet+InterruptTrigger.swift
@@ -1,0 +1,28 @@
+//
+//  DynamicBottomSheet+InterruptTrigger.swift
+//  DynamicBottomSheet
+//
+//  Copyright (c) 2024 Savva Shuliatev
+//  This code is covered by the MIT License.
+//
+
+extension DynamicBottomSheet {
+
+  public struct InterruptTrigger: OptionSet, Sendable {
+
+    public let rawValue: Int
+
+    public static let panGesture = InterruptTrigger(rawValue: 1 << 0)
+    public static let scrollDragging = InterruptTrigger(rawValue: 1 << 1)
+    public static let program = InterruptTrigger(rawValue: 1 << 2)
+
+    public static let all: InterruptTrigger = [.panGesture, .scrollDragging, .program,]
+    public static let empty: InterruptTrigger = []
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+
+  }
+
+}

--- a/Sources/DynamicBottomSheet/DynamicBottomSheetAnimation.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheetAnimation.swift
@@ -17,4 +17,5 @@ import Foundation
 public protocol DynamicBottomSheetAnimation: AnyObject {
   var y: CGFloat { get set }
   var isDone: Bool { get }
+  var interruptTriggers: DynamicBottomSheet.InterruptTrigger { get }
 }

--- a/Sources/DynamicBottomSheet/DynamicBottomSheetDefaultSpringAnimation.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheetDefaultSpringAnimation.swift
@@ -32,6 +32,7 @@ internal final class DynamicBottomSheetDefaultSpringAnimation: DynamicBottomShee
     initialOrigin: CGFloat,
     targetOrigin: CGFloat,
     initialVelocity: CGFloat,
+    interruptTriggers: DynamicBottomSheet.InterruptTrigger,
     parameters: DynamicBottomSheet.AnimationParameters,
     onUpdate: @escaping (CGFloat) -> Void,
     completion: @escaping (Bool) -> Void
@@ -39,6 +40,7 @@ internal final class DynamicBottomSheetDefaultSpringAnimation: DynamicBottomShee
     self.currentOrigin = initialOrigin
     self.currentVelocity = initialVelocity
     self.y = targetOrigin
+    self.interruptTriggers = interruptTriggers
     self.parameters = parameters
     self.threshold = 0.5
     self.onUpdate = onUpdate
@@ -62,6 +64,8 @@ internal final class DynamicBottomSheetDefaultSpringAnimation: DynamicBottomShee
   var isDone: Bool {
     return animation?.running ?? false
   }
+
+  var interruptTriggers: DynamicBottomSheet.InterruptTrigger
 
   // MARK: - Private
 

--- a/Sources/DynamicBottomSheet/UIBottomSheet+Detents.swift
+++ b/Sources/DynamicBottomSheet/UIBottomSheet+Detents.swift
@@ -70,13 +70,18 @@ extension DynamicBottomSheet {
     open func move(
       to position: RelativePosition,
       animated: Bool = true,
+      interruptTriggers: DynamicBottomSheet.InterruptTrigger = .all,
       completion: ((Bool) -> Void)? = nil
     ) {
-      guard let bottomSheet, bottomSheet.didLayoutSubviews else { return }
+      guard let bottomSheet, bottomSheet.didLayoutSubviews else {
+        initialPosition = position
+        return
+      }
 
       bottomSheet.scroll(
         to: y(for: position),
         animated: animated,
+        interruptTriggers: interruptTriggers,
         completion: completion
       )
     }


### PR DESCRIPTION
This functionality is implemented through the InterruptTrigger structure, providing a flexible mechanism for setting triggers that can interrupt animations.
Description of the InterruptTrigger Feature
InterruptTrigger is a structure implementing the OptionSet and Sendable protocols. It allows developers to specify which types of interactions can interrupt the current movement or scroll animation of the BottomSheet. Here are the key components:
panGesture: Interrupts the animation when a pan gesture is detected. This allows users to directly move the BottomSheet using touch interactions.
scrollDragging: Interrupts when scrolling within a list contained in the BottomSheet is detected.
program: The interruption is triggered programmatically. This type of interruption can be initiated by code and is useful for more complex transition scenarios.
all: A preset value that allows all possible triggers to interrupt the animation.
empty: Disables any interruptions, which is useful for creating animations that must complete without being stopped.