### PR TITLE
Combine support

### DIFF
--- a/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
@@ -110,11 +110,11 @@ open class DynamicBottomSheet: UIView {
     }
   }
 
-  internal var anchors: [CGFloat] = []
+  public var anchors: [CGFloat] = []
 
-  internal var didLayoutSubviews = false
+  public private(set) var didLayoutSubviews = false
 
-  private var anchorLimits: ClosedRange<CGFloat>? {
+  public var anchorLimits: ClosedRange<CGFloat>? {
     if let min = anchors.min(), let max = anchors.max() {
       return min...max
     } else {

--- a/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
@@ -11,6 +11,7 @@
 //
 
 import UIKit
+import Combine
 
 open class DynamicBottomSheet: UIView {
 
@@ -48,8 +49,8 @@ open class DynamicBottomSheet: UIView {
   /// Animation parameters for the transitions between anchors
   open var animationParameters: AnimationParameters = Values.default.animationParameters
 
-  open var onFirstAppear: (() -> Void)?
-  open var onChangeY: ((CGFloat) -> Void)?
+  public let onFirstAppear = PassthroughSubject<Void, Never>()
+  public let onChangeY = PassthroughSubject<CGFloat, Never>()
 
   public let visibleView = UIView()
   public let view = UIView()
@@ -172,7 +173,7 @@ open class DynamicBottomSheet: UIView {
       layer.shadowRadius = shadowRadius
       layer.shadowPath = shadowPath
 
-      onFirstAppear?()
+      onFirstAppear.send()
     }
 
     if lastViewGeometry != ViewGeometry(of: self) {
@@ -761,7 +762,8 @@ extension DynamicBottomSheet {
     subscribers.forEach {
       $0.bottomSheet(self, didUpdateY: y, source: source)
     }
-    onChangeY?(y)
+
+    onChangeY.send(y)
   }
 
   private func sendDidEndUpdatingY(with source: YChangeSource) {

--- a/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
@@ -110,7 +110,7 @@ open class DynamicBottomSheet: UIView {
     }
   }
 
-  internal var anchors: [CGFloat] = []
+  public internal(set) var anchors: [CGFloat] = []
 
   public private(set) var didLayoutSubviews = false
 
@@ -236,7 +236,6 @@ open class DynamicBottomSheet: UIView {
     subscribers.unsubscribe(subscriber)
   }
 
-  public func currentAnchors() -> [CGFloat] { anchors }
 }
 
 // MARK: Setup UI

--- a/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
+++ b/Sources/DynamicBottomSheet/DynamicBottomSheet.swift
@@ -110,7 +110,7 @@ open class DynamicBottomSheet: UIView {
     }
   }
 
-  public var anchors: [CGFloat] = []
+  internal var anchors: [CGFloat] = []
 
   public private(set) var didLayoutSubviews = false
 
@@ -235,6 +235,8 @@ open class DynamicBottomSheet: UIView {
   open func unsubscribe(_ subscriber: DynamicBottomSheetSubscriber) {
     subscribers.unsubscribe(subscriber)
   }
+
+  public func currentAnchors() -> [CGFloat] { anchors }
 }
 
 // MARK: Setup UI

--- a/Sources/DynamicBottomSheet/Realizations/DynamicBottomSheetSubscriber.swift
+++ b/Sources/DynamicBottomSheet/Realizations/DynamicBottomSheetSubscriber.swift
@@ -81,3 +81,71 @@ public extension DynamicBottomSheetSubscriber {
     velocity: CGFloat?
   ) {}
 }
+
+// MARK: Contexts for publishers
+
+extension DynamicBottomSheet {
+
+  public struct WillBeginUpdatingYContext: Sendable, Equatable {
+    public let y: CGFloat
+    public let source: DynamicBottomSheet.YChangeSource
+
+    public init(y: CGFloat, source: DynamicBottomSheet.YChangeSource) {
+      self.y = y
+      self.source = source
+    }
+  }
+
+  public struct DidUpdateYContext: Sendable, Equatable {
+    public let y: CGFloat
+    public let source: DynamicBottomSheet.YChangeSource
+
+    public init(y: CGFloat, source: DynamicBottomSheet.YChangeSource) {
+      self.y = y
+      self.source = source
+    }
+  }
+
+  public struct DidEndUpdatingYContext: Sendable, Equatable {
+    public let y: CGFloat
+    public let source: DynamicBottomSheet.YChangeSource
+
+    public init(y: CGFloat, source: DynamicBottomSheet.YChangeSource) {
+      self.y = y
+      self.source = source
+    }
+  }
+
+  public struct WillBeginAnimationContext {
+    public let animation: DynamicBottomSheetAnimation
+    public let source: DynamicBottomSheet.YChangeSource
+
+    public init(animation: DynamicBottomSheetAnimation, source: DynamicBottomSheet.YChangeSource) {
+      self.animation = animation
+      self.source = source
+    }
+  }
+
+  public struct WillMoveToContext: Sendable, Equatable {
+    public let newY: CGFloat
+    public let source: DynamicBottomSheet.YChangeSource
+    public let animated: Bool
+    public let interruptTriggers: DynamicBottomSheet.InterruptTrigger
+    public let velocity: CGFloat?
+
+    public init(
+      newY: CGFloat,
+      source: DynamicBottomSheet.YChangeSource,
+      animated: Bool,
+      interruptTriggers: DynamicBottomSheet.InterruptTrigger,
+      velocity: CGFloat?
+    ) {
+      self.newY = newY
+      self.source = source
+      self.animated = animated
+      self.interruptTriggers = interruptTriggers
+      self.velocity = velocity
+    }
+  }
+
+}


### PR DESCRIPTION
This MR introduces a significant enhancement to the DynamicBottomSheet API by duplicating the existing functionality of the DynamicBottomSheetDetentsSubscriber protocol using Combine's PassthroughSubject.

Previously, you can subscribe with protocol:
```Swift
public protocol DynamicBottomSheetDetentsSubscriber {
  func bottomSheet(
    _ bottomSheet: DynamicBottomSheet,
    didChangePosition position: RelativePosition,
    source: DynamicBottomSheet.YChangeSource
  )
}
```
With this MR, you can now also subscribe to changes using Combine. We have added some PassthroughSubjects to the DynamicBottomSheet, like:
```Swift
public let onChangePosition = PassthroughSubject<DidChangePositionContext, Never>()
```
This provides a more modern and flexible way to handle updates, allowing seamless integration into reactive pipelines. Developers can now choose their preferred mechanism—protocol-based delegation or Combine-based reactive streams—to handle events.
The new Combine-based API does not break existing functionality. Protocol-based subscription will continue to work as before, ensuring full backward compatibility.
This change empowers developers working on a reactive architecture while maintaining support for the existing delegate-based approach.